### PR TITLE
Search links were returning decomposed URI. 

### DIFF
--- a/src/main/java/com/palantir/stash/codesearch/search/SearchServlet.java
+++ b/src/main/java/com/palantir/stash/codesearch/search/SearchServlet.java
@@ -471,7 +471,7 @@ public class SearchServlet extends HttpServlet {
                 .put("statistics", statistics)
                 .put("error", error)
                 .put("fullUri", fullUri)
-                .put("baseUrl", propertiesService.getBaseUrl())
+                .put("baseUrl", propertiesService.getBaseUrl().toASCIIString())
                 .put("resultFrom", Math.min(totalHits, params.page * pageSize + 1))
                 .put("resultTo", Math.min(totalHits, (params.page + 1) * pageSize))
                 .put("searchTime", searchTime)


### PR DESCRIPTION
It seems like something changed with the URI toString behavior when concatenating to a string(java version, or maybe it was the applicationService.getBaseURL(). I Had to explicitly call URI.toAsciiString() now for baseUrl. Otherwise my a href would end up like a decomposed version of the URI plus the project/repo/commit that it already should be there

So i got this ----

a href="{absolute: true, authority: stash.domain.com, fragment: null, host: scm.principal.com, opaque: false, path: , port: -1, query: null, rawAuthority: stash.domain.com, rawFragment: null, rawPath: , rawQuery: null, rawSchemeSpecificPart: //stash.domain.com, rawUserInfo: null, scheme: https, schemeSpecificPart: //stash.domain.com, userInfo: null}
/projects/REPO">

instead of ----

<a href="https://stash.domain.com/project/REPO">

